### PR TITLE
Added datetime convertor function and set user context middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ import {
   buildApiResponse,
   logger,
   convertIdToPrettyString,
-  convertPrettyStringToId
+  convertPrettyStringToId,
+  convertToNativeTimeZone,
+  RequestContext
 } from './src/utils/index.js';
 import { errorHandler } from './src/middlewares/index.js';
 import { Service } from './src/templates/index.js';
@@ -25,5 +27,7 @@ export {
   Service,
   exec,
   convertIdToPrettyString,
-  convertPrettyStringToId
+  convertPrettyStringToId,
+  convertToNativeTimeZone,
+  RequestContext
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express-rate-limit": "^7.5.0",
         "geoip-lite": "^1.4.10",
         "knex": "^3.1.0",
+        "luxon": "^3.6.1",
         "pg": "^8.14.1",
         "pg-pool": "^3.8.0",
         "winston": "^3.17.0"
@@ -1449,6 +1450,15 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express-rate-limit": "^7.5.0",
     "geoip-lite": "^1.4.10",
     "knex": "^3.1.0",
+    "luxon": "^3.6.1",
     "pg": "^8.14.1",
     "pg-pool": "^3.8.0",
     "winston": "^3.17.0"

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -3,5 +3,11 @@
 import errorHandler from './errorHandler.middleware.js';
 import userContext from './userContext.middleware.js';
 import fetchGeoDetailsMiddleware from './geoIP.middleware.js';
+import requestContextMiddleware from './setUserContext.middleware.js';
 
-export { errorHandler, userContext, fetchGeoDetailsMiddleware };
+export {
+  errorHandler,
+  userContext,
+  fetchGeoDetailsMiddleware,
+  requestContextMiddleware,
+};

--- a/src/middlewares/setUserContext.middleware.js
+++ b/src/middlewares/setUserContext.middleware.js
@@ -1,0 +1,19 @@
+'use strict';
+
+import { RequestContext } from '../utils/index.js';
+
+const requestContextMiddleware = (req, res, next) => {
+  const userData = {
+    country: req.geo.country || null,
+    region: req.geo.region || null,
+    city: req.geo.city || null,
+    timezone: req.geo.timezone || 'Asia/Kolkata',
+    language: 'eng',
+  };
+
+  RequestContext.run(userData, () => {
+    next();
+  });
+};
+
+export default requestContextMiddleware;

--- a/src/templates/service-template.js
+++ b/src/templates/service-template.js
@@ -13,13 +13,19 @@ import {
   userContext,
   errorHandler,
   fetchGeoDetailsMiddleware,
+  requestContextMiddleware,
 } from '../middlewares/index.js';
 import { generalServiceConfig } from '../../constants.js';
 
 const log = logger('service-template');
 
 class Service {
-  constructor(serviceConfig, cookieEnable = false, openApiEnabled = true) {
+  constructor(
+    serviceConfig,
+    cookieEnable = false,
+    openApiEnabled = true,
+    setUserContext = true
+  ) {
     log.debug('Service constructor has been called');
     this.app = express();
 
@@ -33,6 +39,7 @@ class Service {
     this.cookieEnable = cookieEnable;
     this.openApiEnabled = openApiEnabled;
     this.serviceConfig = serviceConfig;
+    this.setUserContext = setUserContext;
 
     const mainModulePath = process.argv[1];
     const appRoot = path.dirname(mainModulePath);
@@ -111,6 +118,14 @@ Service.prototype.getUserContext = function () {
   this.app.use(userContext);
 };
 
+Service.prototype.setUserContextFn = function () {
+  // Initialize User Context
+  if (this.setUserContext) {
+    log.debug('App user context middleware initialization');
+    this.app.use(requestContextMiddleware);
+  }
+};
+
 Service.prototype.ipGeoResolver = function () {
   log.debug('Global Geo details from IP middleware initialized');
   this.app.use(fetchGeoDetailsMiddleware);
@@ -133,6 +148,7 @@ Service.prototype.buildConnection = function () {
   }
 
   this.ipGeoResolver();
+  this.setUserContextFn();
   this.registerServiceEndpoints();
   this.registerErrorHandler();
 

--- a/src/utils/RequestContext.js
+++ b/src/utils/RequestContext.js
@@ -1,0 +1,18 @@
+'use strict';
+
+import { AsyncLocalStorage } from 'async_hooks';
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+const RequestContext = {
+  run: (data, callback) => asyncLocalStorage.run(data, callback),
+  get: () => asyncLocalStorage.getStore(),
+  set: (key, value) => {
+    const store = asyncLocalStorage.getStore();
+    if (store) {
+      store[key] = value;
+    }
+  },
+};
+
+export default RequestContext;

--- a/src/utils/dateTimeConvertor.js
+++ b/src/utils/dateTimeConvertor.js
@@ -1,0 +1,16 @@
+'use strict';
+
+import { DateTime } from 'luxon';
+import { RequestContext } from './index.js';
+
+const convertToNativeTimeZone = (serverDateStr) => {
+  const userContext = RequestContext.get();
+  const userTimezone = userContext.timezone;
+
+  const userLocalDate = DateTime.fromJSDate(new Date(serverDateStr))
+    .setZone(userTimezone)
+    .toFormat('dd-MM-yyyy HH:mm:ss');
+  return userLocalDate;
+};
+
+export { convertToNativeTimeZone };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,6 +7,8 @@ import {
   convertIdToPrettyString,
   convertPrettyStringToId,
 } from './convertId.js';
+import { convertToNativeTimeZone } from './dateTimeConvertor.js';
+import RequestContext from './requestContext.js';
 
 export {
   buildApiError,
@@ -14,4 +16,6 @@ export {
   logger,
   convertIdToPrettyString,
   convertPrettyStringToId,
+  convertToNativeTimeZone,
+  RequestContext,
 };


### PR DESCRIPTION
- Added a Datetime convertor function - convertToNativeTimeZone which takes the server datetime and convert it to user local datetime based on the user timezone.
- Added a RequestContext function to set and get the user-context data for each request and once the request is completed the data will get auto-destroyed.
- Initialized a middleware which currently stores the user context data like country, region, city, timezone, & language. This middleware will be called before the request function processing start.